### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 * text=auto
 *.sh eol=lf
+*.snap eol=lf
+dist/* eol=lf linguist-generated


### PR DESCRIPTION
- Use `eof=lf` for files in `dist` and `.snap` files to avoid phantom changes when working on Windows after regenerating files.
- Mark files in `dist` as generated code.
